### PR TITLE
Add pause and resume functionality for Pomodoro sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `auto_continue_delay` configuration option (default: 3 seconds)
 - Countdown notification before auto-start
 - Auto-continue can be cancelled with `:SpartanStop`
+- Pause/Resume functionality for handling interruptions
+- `:SpartanPause` command to pause current session
+- `:SpartanResume` command to resume paused session
+- `pause()` and `resume()` Lua API functions
+- Paused state preserves remaining time and callbacks
+- Blocker UI hides during pause and shows again on resume (for breaks)
 
 ## [1.0.0] - 2025-01-22
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ require("spartan-pomo").setup({
 |---------|-------------|
 | `:SpartanStart` | Start a Pomodoro session |
 | `:SpartanStop` | Stop the current session |
+| `:SpartanPause` | Pause the current session |
+| `:SpartanResume` | Resume the paused session |
 | `:SpartanStatus` | Show current session status and completed count |
 | `:SpartanReset` | Reset completed Pomodoro count |
 
@@ -142,6 +144,8 @@ local pomo = require("spartan-pomo")
 
 pomo.start()        -- Start a session
 pomo.stop()         -- Stop the session
+pomo.pause()        -- Pause the current session
+pomo.resume()       -- Resume the paused session
 pomo.reset_count()  -- Reset completed count
 pomo.get_status()   -- Get current status {state, remaining, remaining_seconds, completed_count}
 pomo.get_config()   -- Get current configuration

--- a/doc/spartan-pomo.txt
+++ b/doc/spartan-pomo.txt
@@ -130,6 +130,16 @@ ascii_art ~
   Stop the current Pomodoro session. If in break mode, the blocker
   will be hidden immediately.
 
+                                                              *:SpartanPause*
+:SpartanPause
+  Pause the current Pomodoro session. Timer stops and blocker hides
+  (if active). Remaining time is preserved.
+
+                                                             *:SpartanResume*
+:SpartanResume
+  Resume the paused Pomodoro session. Timer continues from where it
+  was paused. Blocker shows again if it was a break session.
+
                                                              *:SpartanStatus*
 :SpartanStatus
   Display the current session status (state, remaining time, and
@@ -169,6 +179,14 @@ get_status()
                                                   *spartan-pomo.reset_count()*
 reset_count()
   Reset the completed Pomodoro count to 0.
+
+                                                        *spartan-pomo.pause()*
+pause()
+  Pause the current Pomodoro session.
+
+                                                       *spartan-pomo.resume()*
+resume()
+  Resume the paused Pomodoro session.
 
                                                    *spartan-pomo.get_config()*
 get_config()

--- a/plugin/spartan-pomo.lua
+++ b/plugin/spartan-pomo.lua
@@ -23,6 +23,12 @@ vim.api.nvim_create_user_command("SpartanStatus", function()
       vim.log.levels.INFO,
       { title = "Spartan Pomo" }
     )
+  elseif status.state == "paused" then
+    vim.notify(
+      string.format("Paused - %s remaining (Completed: %d)", status.remaining, status.completed_count),
+      vim.log.levels.INFO,
+      { title = "Spartan Pomo" }
+    )
   else
     local state_display = status.state == "work" and "Working" or "Break"
     vim.notify(
@@ -36,3 +42,11 @@ end, { desc = "Show current Pomodoro status" })
 vim.api.nvim_create_user_command("SpartanReset", function()
   require("spartan-pomo").reset_count()
 end, { desc = "Reset completed Pomodoro count" })
+
+vim.api.nvim_create_user_command("SpartanPause", function()
+  require("spartan-pomo").pause()
+end, { desc = "Pause the current Pomodoro session" })
+
+vim.api.nvim_create_user_command("SpartanResume", function()
+  require("spartan-pomo").resume()
+end, { desc = "Resume the paused Pomodoro session" })


### PR DESCRIPTION
## Description

Add pause and resume commands to enhance the Pomodoro timer functionality, allowing users to handle interruptions more effectively. The implementation preserves the remaining time and updates the UI accordingly during pauses.

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->
<!-- Fixes #123 -->
Fixes #5

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [x] My code follows the existing code style
- [x] I have updated the documentation (if applicable)
- [x] I have added comments for complex logic (if applicable)

## Testing

```lua
-- Test configuration used
require("spartan-pomo").setup({
  work_time = 0.1,
  break_time = 0.1,
})
```

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Any other information that reviewers should know -->

